### PR TITLE
fix: fixing issue with continueGenerate and reasoning being enabled

### DIFF
--- a/frontend/src/components/InputChatContent.tsx
+++ b/frontend/src/components/InputChatContent.tsx
@@ -53,7 +53,7 @@ type Props = BaseProps & {
     attachments?: AttachmentType[]
   ) => void;
   onRegenerate: (enableReasoning: boolean) => void;
-  continueGenerate: () => void;
+  continueGenerate: (enabledReasoning: boolean) => void;
   supportReasoning: boolean;
   reasoningEnabled: boolean;
   onChangeReasoning: (enabled: boolean) => void;
@@ -574,7 +574,9 @@ const InputChatContent = forwardRef<HTMLElement, Props>(
                   <Button
                     className="bg-aws-paper-light p-2 text-sm dark:bg-aws-paper-dark"
                     outlined
-                    onClick={props.continueGenerate}>
+                    onClick={()=> {
+                      props.continueGenerate(reasoningEnabled);
+                    }}>
                     <PiArrowFatLineRight className="mr-2" />
                     {t('button.continue')}
                   </Button>

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -515,6 +515,7 @@ const useChat = () => {
   const continueGenerate = (params?: {
     messageId?: string;
     bot?: BotInputType;
+    enableReasoning: boolean;
   }) => {
     setPostingMessage(true);
 
@@ -534,7 +535,7 @@ const useChat = () => {
       },
       botId: params?.bot?.botId,
       continueGenerate: true,
-      enableReasoning: false,
+      enableReasoning: params?.enableReasoning ?? false,
     };
 
     const lastMessage = messages[messages.length - 1];

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -234,8 +234,12 @@ const ChatPage: React.FC = () => {
     [inputBotParams, regenerate]
   );
 
-  const onContinueGenerate = useCallback(() => {
-    continueGenerate({ bot: inputBotParams });
+  const onContinueGenerate = useCallback(
+    (enableReasoning: boolean) => {
+      continueGenerate({
+        bot: inputBotParams,
+        enableReasoning
+      });
   }, [inputBotParams, continueGenerate]);
 
   useLayoutEffect(() => {


### PR DESCRIPTION
*Issue #, if available:*
#6 

*Description of changes:*
Updates chat components and state infrastructure to make it function more like `regenerate` and pass the reasoning mode back to bedrock

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
